### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-## [1.0.0] - 2021-03-15
+## [1.1.0] - 2021-03-16
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-atspoke",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A JupiterOne Integration for atSpoke",
   "license": "MPL-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
Releases change to drop the `numRequests` config and will fetch back 14 days on first run, then since last successful execution time.